### PR TITLE
Add `-chdir` flag to cd into infra folder

### DIFF
--- a/.github/workflows/tf-main.yml
+++ b/.github/workflows/tf-main.yml
@@ -99,4 +99,4 @@ jobs:
 
     - name: Terraform Apply
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: terraform apply -auto-approve -input=false
+      run: terraform -chdir=./infra apply -auto-approve -input=false


### PR DESCRIPTION
## Context 

This PR adds a `-chdir` flag, to cd into the infra folder before `terraform apply` is executed. 