### PR TITLE
Create VPC subnets

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,8 +1,19 @@
 resource "aws_vpc" "vpc" {
-  cidr_block = var.env_cblocks[terraform.workspace]
-  count      = var.environment[terraform.workspace] ? 1 : 0
+  cidr_block = var.environment[terraform.workspace].network_id
 
   tags = {
     Name = "${terraform.workspace}-network"
+  }
+}
+
+resource "aws_subnet" "subnet" {
+  for_each                = var.environment[terraform.workspace].subnets
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = each.value.network_id
+  availability_zone       = each.value.availability_zone
+  map_public_ip_on_launch = each.value.map_public_ip_on_launch
+
+  tags = {
+    Name = "${terraform.workspace}-${each.key}"
   }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -16,14 +16,14 @@ variable "environment" {
           "availability_zone"       = "eu-west-1b"
         },
         "data_aza" = {
-          "network_id"        = "10.0.128.0/18"
+          "network_id"              = "10.0.128.0/18"
           "map_public_ip_on_launch" = false
-          "availability_zone" = "eu-west-1a"
+          "availability_zone"       = "eu-west-1a"
         },
         "data_azb" = {
-          "network_id"        = "10.0.192.0/18"
+          "network_id"              = "10.0.192.0/18"
           "map_public_ip_on_launch" = false
-          "availability_zone" = "eu-west-1b"
+          "availability_zone"       = "eu-west-1b"
         }
       }
     },
@@ -42,14 +42,14 @@ variable "environment" {
           "availability_zone"       = "eu-west-1b"
         },
         "data_aza" = {
-          "network_id"        = "192.168.128.0/18"
+          "network_id"              = "192.168.128.0/18"
           "map_public_ip_on_launch" = false
-          "availability_zone" = "eu-west-1a"
+          "availability_zone"       = "eu-west-1a"
         },
         "data_azb" = {
-          "network_id"        = "192.168.192.0/18"
+          "network_id"              = "192.168.192.0/18"
           "map_public_ip_on_launch" = false
-          "availability_zone" = "eu-west-1b"
+          "availability_zone"       = "eu-west-1b"
         }
       }
     }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,16 +1,57 @@
 variable "environment" {
-  type = map(string)
+  type = map(any)
   default = {
-    "production" = true,
-    "staging"    = true
+    "production" = {
+      "apply"      = true
+      "network_id" = "10.0.0.0/16"
+      "subnets" = {
+        "web_aza" = {
+          "network_id"              = "10.0.0.0/18"
+          "map_public_ip_on_launch" = true
+          "availability_zone"       = "eu-west-1a"
+        },
+        "web_azb" = {
+          "network_id"              = "10.0.64.0/18"
+          "map_public_ip_on_launch" = true
+          "availability_zone"       = "eu-west-1b"
+        },
+        "data_aza" = {
+          "network_id"        = "10.0.128.0/18"
+          "map_public_ip_on_launch" = false
+          "availability_zone" = "eu-west-1a"
+        },
+        "data_azb" = {
+          "network_id"        = "10.0.192.0/18"
+          "map_public_ip_on_launch" = false
+          "availability_zone" = "eu-west-1b"
+        }
+      }
+    },
+    "staging" = {
+      "apply"      = true
+      "network_id" = "192.168.0.0/16"
+      "subnets" = {
+        "web_aza" = {
+          "network_id"              = "192.168.0.0/18"
+          "map_public_ip_on_launch" = true
+          "availability_zone"       = "eu-west-1a"
+        },
+        "web_azb" = {
+          "network_id"              = "192.168.64.0/18"
+          "map_public_ip_on_launch" = true
+          "availability_zone"       = "eu-west-1b"
+        },
+        "data_aza" = {
+          "network_id"        = "192.168.128.0/18"
+          "map_public_ip_on_launch" = false
+          "availability_zone" = "eu-west-1a"
+        },
+        "data_azb" = {
+          "network_id"        = "192.168.192.0/18"
+          "map_public_ip_on_launch" = false
+          "availability_zone" = "eu-west-1b"
+        }
+      }
+    }
   }
 }
-
-variable "env_cblocks" {
-  type = map(string)
-  default = {
-    "production" = "10.0.0.0/16"
-    "staging"    = "192.168.0.0/16"
-  }
-}
-


### PR DESCRIPTION
## Context

This PR creates the following resources on AWS:

- Four subnets, two in each availability zone - `eu-west-1a ` & `eu-west-1b`