### PR TITLE
Move tfvars to global scope

### DIFF
--- a/.github/workflows/tf-main.yml
+++ b/.github/workflows/tf-main.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   AWS_REGION: eu-west-1
+  TF_VAR_database: ${{ vars.TF_VAR_DATABASE }}
+  TF_VAR_ipaddr: ${{ vars.TF_VAR_IPADDR }}
 
 permissions:
   id-token: write
@@ -64,9 +66,6 @@ jobs:
 
     - name: Terraform Plan
       id: plan
-      env:
-        TF_VAR_database: ${{ vars.TF_VAR_DATABASE }}
-        TF_VAR_ipaddr: ${{ vars.TF_VAR_IPADDR }}
       run: terraform -chdir=./infra plan
       continue-on-error: true
     


### PR DESCRIPTION
## Context

I need to move the `database` and `ip address` variables from the `Terraform Plan` step to a global step for them to be accessed by the  `Terraform Apply` step.